### PR TITLE
add resource labels for metadata

### DIFF
--- a/terraform-gke/files/k8s-control-plane.tf
+++ b/terraform-gke/files/k8s-control-plane.tf
@@ -4,4 +4,10 @@ resource "google_container_cluster" "primary" {
   remove_default_node_pool = true
   initial_node_count       = 1
   min_master_version       = var.k8s_version
+  
+  resource_labels          = {
+    environment            = "development"
+    created-by             = "terraform"
+    owner                  = "vfarcic"
+  }
 }

--- a/terraform-gke/files/storage.tf
+++ b/terraform-gke/files/storage.tf
@@ -4,4 +4,9 @@ resource "google_storage_bucket" "state" {
   force_destroy = true
   project       = var.project_id
   storage_class = "NEARLINE"
+  labels        = {
+    environment = "development"
+    created-by  = "terraform"
+    owner       = "vfarcic"
+  }
 }


### PR DESCRIPTION
Adding resource labels for metadata to the container cluster and storage bucket. 
Node pools do not have labels, anotother PR (to devops-catalog) contains mirrored changed to reflect the changes in these files.