### PR TITLE
Fix panic: error parsing uri: scheme must be \"mongodb\" or \"mongodb…

### DIFF
--- a/helm/go-demo-9/templates/deployment.yaml
+++ b/helm/go-demo-9/templates/deployment.yaml
@@ -25,7 +25,8 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: DB
-          value: {{ template "name" . }}-mongodb
+          #value: {{ template "name" . }}-mongodb
+          value: mongodb://{{ template "name" . }}-{{ template "name" .  }}-db
         - name: VERSION
           value: {{ .Values.image.tag }}
         ports:


### PR DESCRIPTION
Fix:
Starting the application
Connecting DB go-demo-9-mongodb
panic: error parsing uri: scheme must be "mongodb" or "mongodb+srv"

goroutine 1 [running]:
main.setupDb()
        /src/main.go:85 +0x2e9
main.main()
        /src/main.go:59 +0x9c