### PR TITLE
Set ingressClassName since from 1.22 it is mandatory

### DIFF
--- a/argo/argocd-values.yaml
+++ b/argo/argocd-values.yaml
@@ -1,6 +1,7 @@
 server:
   ingress:
     enabled: true
+    ingressClassName: nginx
   extraArgs:
   - --insecure
 installCRDs: false


### PR DESCRIPTION
As I understand from kubernetes 1.22 spec.ingressClassName became mandatory and annotation is not enough.

Without it no records upstream:
`kubectl ingress-nginx backends upstream-default-backend --deployment my-nginx-ingress-nginx-controller -n ingress-nginx`
